### PR TITLE
feat: Rig Qwen TTS custom voices (design-once, clone-profile workflow)

### DIFF
--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -318,6 +318,11 @@ fun SettingsScreen(
     var openAiApiKey by rememberSaveable { mutableStateOf(settings.openAiApiKey) }
     var openAiVoice by rememberSaveable { mutableStateOf(settings.openAiVoice) }
     var showOpenAiApiKey by rememberSaveable { mutableStateOf(false) }
+
+    // Rig Qwen TTS
+    var rigQwenUrl by rememberSaveable { mutableStateOf(settings.rigQwenUrl) }
+    var rigQwenSpeaker by rememberSaveable { mutableStateOf(settings.rigQwenSpeaker) }
+    var rigQwenCustomVoices by rememberSaveable { mutableStateOf(settings.rigQwenCustomVoices) }
     
     // VOICEVOX
     var voiceVoxStyleId by rememberSaveable { mutableStateOf(settings.voiceVoxStyleId) }
@@ -504,6 +509,9 @@ fun SettingsScreen(
                                 settings.elevenLabsSpeed = elevenLabsSpeed
                                 settings.openAiApiKey = openAiApiKey
                                 settings.openAiVoice = openAiVoice
+                                settings.rigQwenUrl = rigQwenUrl
+                                settings.rigQwenSpeaker = rigQwenSpeaker
+                                settings.rigQwenCustomVoices = rigQwenCustomVoices
                                 settings.voiceVoxStyleId = voiceVoxStyleId
                                 settings.voiceVoxTermsAccepted = voiceVoxTermsAccepted
                                 settings.continuousMode = continuousMode
@@ -1140,6 +1148,7 @@ fun SettingsScreen(
                                 SettingsRepository.TTS_TYPE_ELEVENLABS -> "ElevenLabs"
                                 SettingsRepository.TTS_TYPE_OPENAI -> "OpenAI"
                                 SettingsRepository.TTS_TYPE_VOICEVOX -> "VOICEVOX"
+                                SettingsRepository.TTS_TYPE_RIG_QWEN -> "Rig Qwen TTS"
                                 else -> "System TTS"
                             }
                             
@@ -1206,6 +1215,18 @@ fun SettingsScreen(
                                         }
                                     )
                                 }
+                                DropdownMenuItem(
+                                    text = { Text("Rig Qwen TTS") },
+                                    onClick = {
+                                        ttsType = SettingsRepository.TTS_TYPE_RIG_QWEN
+                                        showTtsTypeMenu = false
+                                    },
+                                    leadingIcon = {
+                                        if (ttsType == SettingsRepository.TTS_TYPE_RIG_QWEN) {
+                                            Icon(Icons.Default.Check, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                                        }
+                                    }
+                                )
                             }
                         }
 
@@ -1245,6 +1266,17 @@ fun SettingsScreen(
                                         onTermsAcceptedChange = { voiceVoxTermsAccepted = it }
                                     )
                                 }
+                            }
+                            SettingsRepository.TTS_TYPE_RIG_QWEN -> {
+                                Spacer(modifier = Modifier.height(16.dp))
+                                RigQwenSettingsCard(
+                                    url = rigQwenUrl,
+                                    onUrlChange = { rigQwenUrl = it },
+                                    speaker = rigQwenSpeaker,
+                                    onSpeakerChange = { rigQwenSpeaker = it },
+                                    customVoicesJson = rigQwenCustomVoices,
+                                    onCustomVoicesChange = { rigQwenCustomVoices = it }
+                                )
                             }
                             else -> {
                                 // System TTS - show engine selection
@@ -2553,6 +2585,209 @@ fun OpenAISettingsCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun RigQwenSettingsCard(
+    url: String,
+    onUrlChange: (String) -> Unit,
+    speaker: String,
+    onSpeakerChange: (String) -> Unit,
+    customVoicesJson: String,
+    onCustomVoicesChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val builtinSpeakers = com.openclaw.assistant.speech.RigQwenTTSProvider.RIG_QWEN_SPEAKERS
+    val customVoices = remember(customVoicesJson) {
+        com.openclaw.assistant.speech.RigQwenTTSProvider.parseCustomVoices(customVoicesJson)
+    }
+    var speakerExpanded by remember { mutableStateOf(false) }
+    var showAddDialog by remember { mutableStateOf(false) }
+    var newName by remember { mutableStateOf("") }
+    var newInstruct by remember { mutableStateOf("") }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "Rig Qwen TTS Settings",
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            OutlinedTextField(
+                value = url,
+                onValueChange = onUrlChange,
+                label = { Text(stringResource(R.string.rig_qwen_url_label)) },
+                placeholder = { Text("http://100.95.34.108:8799") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
+            )
+            Text(
+                "Qwen3-TTS CustomVoice server (rig_tts_server.py). No API key needed.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Speaker picker: built-in timbres + user custom voices.
+            val allSpeakers = builtinSpeakers + customVoices.map { it.name }
+            ExposedDropdownMenuBox(
+                expanded = speakerExpanded,
+                onExpandedChange = { speakerExpanded = it }
+            ) {
+                OutlinedTextField(
+                    value = speaker,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.rig_qwen_speaker_label)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = speakerExpanded) },
+                    modifier = Modifier.fillMaxWidth().menuAnchor()
+                )
+
+                ExposedDropdownMenu(
+                    expanded = speakerExpanded,
+                    onDismissRequest = { speakerExpanded = false }
+                ) {
+                    builtinSpeakers.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option) },
+                            onClick = {
+                                onSpeakerChange(option)
+                                speakerExpanded = false
+                            },
+                            leadingIcon = {
+                                if (speaker == option) {
+                                    Icon(Icons.Default.Check, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                                }
+                            }
+                        )
+                    }
+                    if (customVoices.isNotEmpty()) {
+                        HorizontalDivider()
+                        customVoices.forEach { cv ->
+                            DropdownMenuItem(
+                                text = {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Icon(
+                                            Icons.Default.Star,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Text(cv.name)
+                                    }
+                                },
+                                onClick = {
+                                    onSpeakerChange(cv.name)
+                                    speakerExpanded = false
+                                },
+                                leadingIcon = {
+                                    if (speaker == cv.name) {
+                                        Icon(Icons.Default.Check, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Custom voice management
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                "Custom Voices (VoiceDesign prompts)",
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            if (customVoices.isEmpty()) {
+                Text(
+                    "No custom voices yet. Add one with a natural-language prompt describing the voice.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                customVoices.forEach { cv ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(cv.name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+                        TextButton(onClick = {
+                            val remaining = customVoices.filter { it.name != cv.name }
+                            onCustomVoicesChange(
+                                com.openclaw.assistant.speech.RigQwenTTSProvider.serializeCustomVoices(remaining)
+                            )
+                        }) {
+                            Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+            }
+            TextButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(stringResource(R.string.rig_qwen_add_custom_voice))
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text(stringResource(R.string.rig_qwen_add_custom_voice)) },
+            text = {
+                Column {
+                    OutlinedTextField(
+                        value = newName,
+                        onValueChange = { newName = it },
+                        label = { Text(stringResource(R.string.rig_qwen_voice_name_label)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = newInstruct,
+                        onValueChange = { newInstruct = it },
+                        label = { Text(stringResource(R.string.rig_qwen_voice_prompt_label)) },
+                        placeholder = { Text("e.g. A warm grandmotherly voice, gentle and patient, with a soft rasp.") },
+                        minLines = 3,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = newName.isNotBlank() && newInstruct.isNotBlank(),
+                    onClick = {
+                        val updated = customVoices + com.openclaw.assistant.speech.RigQwenTTSProvider.RigQwenCustomVoice(
+                            name = newName.trim(),
+                            instruct = newInstruct.trim()
+                        )
+                        onCustomVoicesChange(com.openclaw.assistant.speech.RigQwenTTSProvider.serializeCustomVoices(updated))
+                        newName = ""
+                        newInstruct = ""
+                        showAddDialog = false
+                    }
+                ) {
+                    Text(stringResource(R.string.add))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
+++ b/app/src/main/java/com/openclaw/assistant/SettingsActivity.kt
@@ -2598,6 +2598,8 @@ fun RigQwenSettingsCard(
     onCustomVoicesChange: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val builtinSpeakers = com.openclaw.assistant.speech.RigQwenTTSProvider.RIG_QWEN_SPEAKERS
     val customVoices = remember(customVoicesJson) {
         com.openclaw.assistant.speech.RigQwenTTSProvider.parseCustomVoices(customVoicesJson)
@@ -2606,6 +2608,11 @@ fun RigQwenSettingsCard(
     var showAddDialog by remember { mutableStateOf(false) }
     var newName by remember { mutableStateOf("") }
     var newInstruct by remember { mutableStateOf("") }
+    var newRefText by remember { mutableStateOf("") }
+    var creatingVoice by remember { mutableStateOf(false) }
+    var createError by remember { mutableStateOf<String?>(null) }
+
+    val provider = remember { com.openclaw.assistant.speech.RigQwenTTSProvider(context) }
 
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -2639,7 +2646,6 @@ fun RigQwenSettingsCard(
             Spacer(modifier = Modifier.height(8.dp))
 
             // Speaker picker: built-in timbres + user custom voices.
-            val allSpeakers = builtinSpeakers + customVoices.map { it.name }
             ExposedDropdownMenuBox(
                 expanded = speakerExpanded,
                 onExpandedChange = { speakerExpanded = it }
@@ -2705,13 +2711,13 @@ fun RigQwenSettingsCard(
             // Custom voice management
             Spacer(modifier = Modifier.height(12.dp))
             Text(
-                "Custom Voices (VoiceDesign prompts)",
+                "Custom Voices (one-time design + clone profile)",
                 style = MaterialTheme.typography.titleSmall
             )
             Spacer(modifier = Modifier.height(4.dp))
             if (customVoices.isEmpty()) {
                 Text(
-                    "No custom voices yet. Add one with a natural-language prompt describing the voice.",
+                    "No custom voices yet. Add one with a natural-language prompt describing the voice — it's designed once, then reused like a saved profile.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -2723,10 +2729,13 @@ fun RigQwenSettingsCard(
                     ) {
                         Text(cv.name, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
                         TextButton(onClick = {
-                            val remaining = customVoices.filter { it.name != cv.name }
-                            onCustomVoicesChange(
-                                com.openclaw.assistant.speech.RigQwenTTSProvider.serializeCustomVoices(remaining)
-                            )
+                            scope.launch {
+                                provider.deleteCustomVoice(cv.name)
+                                val remaining = customVoices.filter { it.name != cv.name }
+                                onCustomVoicesChange(
+                                    com.openclaw.assistant.speech.RigQwenTTSProvider.serializeCustomVoices(remaining)
+                                )
+                            }
                         }) {
                             Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error)
                         }
@@ -2743,15 +2752,26 @@ fun RigQwenSettingsCard(
 
     if (showAddDialog) {
         AlertDialog(
-            onDismissRequest = { showAddDialog = false },
+            onDismissRequest = {
+                if (!creatingVoice) showAddDialog = false
+            },
             title = { Text(stringResource(R.string.rig_qwen_add_custom_voice)) },
             text = {
                 Column {
+                    if (createError != null) {
+                        Text(
+                            createError.orEmpty(),
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
                     OutlinedTextField(
                         value = newName,
                         onValueChange = { newName = it },
                         label = { Text(stringResource(R.string.rig_qwen_voice_name_label)) },
                         singleLine = true,
+                        enabled = !creatingVoice,
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(modifier = Modifier.height(8.dp))
@@ -2761,29 +2781,70 @@ fun RigQwenSettingsCard(
                         label = { Text(stringResource(R.string.rig_qwen_voice_prompt_label)) },
                         placeholder = { Text("e.g. A warm grandmotherly voice, gentle and patient, with a soft rasp.") },
                         minLines = 3,
+                        enabled = !creatingVoice,
                         modifier = Modifier.fillMaxWidth()
                     )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = newRefText,
+                        onValueChange = { newRefText = it },
+                        label = { Text(stringResource(R.string.rig_qwen_ref_text_label)) },
+                        placeholder = { Text("(optional) e.g. Hello! This is my voice.") },
+                        minLines = 2,
+                        enabled = !creatingVoice,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    if (creatingVoice) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                "Designing voice & building profile (can take ~1 min on first use)…",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
                 }
             },
             confirmButton = {
                 TextButton(
-                    enabled = newName.isNotBlank() && newInstruct.isNotBlank(),
+                    enabled = newName.isNotBlank() && newInstruct.isNotBlank() && !creatingVoice,
                     onClick = {
-                        val updated = customVoices + com.openclaw.assistant.speech.RigQwenTTSProvider.RigQwenCustomVoice(
-                            name = newName.trim(),
-                            instruct = newInstruct.trim()
-                        )
-                        onCustomVoicesChange(com.openclaw.assistant.speech.RigQwenTTSProvider.serializeCustomVoices(updated))
-                        newName = ""
-                        newInstruct = ""
-                        showAddDialog = false
+                        createError = null
+                        creatingVoice = true
+                        scope.launch {
+                            val result = provider.createCustomVoice(
+                                name = newName,
+                                instruct = newInstruct,
+                                refText = newRefText,
+                            )
+                            creatingVoice = false
+                            result.onSuccess { createdName ->
+                                val updated = customVoices + com.openclaw.assistant.speech.RigQwenTTSProvider.RigQwenCustomVoice(
+                                    name = createdName,
+                                    instruct = newInstruct.trim()
+                                )
+                                onCustomVoicesChange(com.openclaw.assistant.speech.RigQwenTTSProvider.serializeCustomVoices(updated))
+                                newName = ""
+                                newInstruct = ""
+                                newRefText = ""
+                                showAddDialog = false
+                            }.onFailure { e ->
+                                createError = e.message ?: "Failed to create voice"
+                            }
+                        }
                     }
                 ) {
                     Text(stringResource(R.string.add))
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) {
+                TextButton(
+                    enabled = !creatingVoice,
+                    onClick = { showAddDialog = false }
+                ) {
                     Text(stringResource(R.string.cancel))
                 }
             }

--- a/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openclaw/assistant/data/SettingsRepository.kt
@@ -233,6 +233,24 @@ class SettingsRepository(context: Context) {
     var openAiModel: String
         get() = prefs.getString(KEY_OPENAI_MODEL, DEFAULT_OPENAI_MODEL) ?: DEFAULT_OPENAI_MODEL
         set(value) = prefs.edit().putString(KEY_OPENAI_MODEL, value).apply()
+
+    // Rig Qwen TTS settings
+    var rigQwenUrl: String
+        get() = prefs.getString(KEY_RIG_QWEN_URL, DEFAULT_RIG_QWEN_URL) ?: DEFAULT_RIG_QWEN_URL
+        set(value) = prefs.edit().putString(KEY_RIG_QWEN_URL, value).apply()
+
+    var rigQwenSpeaker: String
+        get() = prefs.getString(KEY_RIG_QWEN_SPEAKER, DEFAULT_RIG_QWEN_SPEAKER) ?: DEFAULT_RIG_QWEN_SPEAKER
+        set(value) = prefs.edit().putString(KEY_RIG_QWEN_SPEAKER, value).apply()
+
+    /**
+     * User-defined custom voices for the rig's VoiceDesign endpoint.
+     * Stored as a JSON array of {"name": "...", "instruct": "..."}.
+     * Empty string = no custom voices defined.
+     */
+    var rigQwenCustomVoices: String
+        get() = prefs.getString(KEY_RIG_QWEN_CUSTOM_VOICES, "") ?: ""
+        set(value) = prefs.edit().putString(KEY_RIG_QWEN_CUSTOM_VOICES, value).apply()
     
     // VOICEVOX settings
     var voiceVoxSpeakerId: Int
@@ -413,6 +431,9 @@ class SettingsRepository(context: Context) {
         private const val KEY_OPENAI_API_KEY = "openai_api_key"
         private const val KEY_OPENAI_VOICE = "openai_voice"
         private const val KEY_OPENAI_MODEL = "openai_model"
+        private const val KEY_RIG_QWEN_URL = "rig_qwen_url"
+        private const val KEY_RIG_QWEN_SPEAKER = "rig_qwen_speaker"
+        private const val KEY_RIG_QWEN_CUSTOM_VOICES = "rig_qwen_custom_voices"
         private const val KEY_VOICEVOX_SPEAKER_ID = "voicevox_speaker_id"
         private const val KEY_VOICEVOX_STYLE_ID = "voicevox_style_id"
         private const val KEY_VOICEVOX_TERMS_ACCEPTED = "voicevox_terms_accepted"
@@ -443,6 +464,7 @@ class SettingsRepository(context: Context) {
         const val TTS_TYPE_ELEVENLABS = "elevenlabs"
         const val TTS_TYPE_OPENAI = "openai"
         const val TTS_TYPE_VOICEVOX = "voicevox"
+        const val TTS_TYPE_RIG_QWEN = "rig_qwen"
         
         // Default ElevenLabs voice ID (empty - user must set)
         const val DEFAULT_ELEVENLABS_VOICE_ID = ""
@@ -451,6 +473,10 @@ class SettingsRepository(context: Context) {
         // Default OpenAI voice
         const val DEFAULT_OPENAI_VOICE = "coral"
         const val DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
+
+        // Default Rig Qwen TTS (Windows GPU box, Qwen3-TTS CustomVoice)
+        const val DEFAULT_RIG_QWEN_URL = "http://100.95.34.108:8799"
+        const val DEFAULT_RIG_QWEN_SPEAKER = "ryan"
         
         // Default VOICEVOX speaker (none - user must select and download)
         const val DEFAULT_VOICEVOX_SPEAKER_ID = 0

--- a/app/src/main/java/com/openclaw/assistant/speech/RigQwenTTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/RigQwenTTSProvider.kt
@@ -81,14 +81,13 @@ class RigQwenTTSProvider(private val context: Context) : TTSProvider {
 
         val request: Request
         if (custom != null) {
-            // User-defined custom voice -> VoiceDesign endpoint (prompt-based).
+            // User-defined custom voice -> clone profile path on the rig.
             val requestBody = JSONObject().apply {
                 put("text", text)
-                put("instruct", custom.instruct)
-                put("language", "English")
+                put("voice", custom.name)
             }.toString()
             request = Request.Builder()
-                .url("$baseUrl/voice_design")
+                .url("$baseUrl/tts")
                 .header("Content-Type", "application/json")
                 .post(requestBody.toRequestBody("application/json".toMediaType()))
                 .build()
@@ -126,6 +125,69 @@ class RigQwenTTSProvider(private val context: Context) : TTSProvider {
     /** Persist the custom voice list back to settings. */
     fun saveCustomVoices(voices: List<RigQwenCustomVoice>) {
         settings.rigQwenCustomVoices = serializeCustomVoices(voices)
+    }
+
+    /**
+     * Create a custom voice on the rig: the server designs a reference clip
+     * from [instruct] (VoiceDesign) and builds a reusable clone profile (Base),
+     * persisted server-side keyed by [name]. This is the ElevenLabs-style
+     * one-time "voice profile" creation.
+     *
+     * @return true on success (caller should then persist the voice locally)
+     */
+    suspend fun createCustomVoice(name: String, instruct: String, refText: String): Result<String> =
+        withContext(Dispatchers.IO) {
+            val baseUrl = settings.rigQwenUrl.trim().trimEnd('/')
+            val requestBody = JSONObject().apply {
+                put("name", name.trim())
+                put("instruct", instruct.trim())
+                put("ref_text", refText.trim().ifBlank { "Hello! This is my voice." })
+            }.toString()
+            val request = Request.Builder()
+                .url("$baseUrl/voice_create")
+                .header("Content-Type", "application/json")
+                .post(requestBody.toRequestBody("application/json".toMediaType()))
+                .build()
+            try {
+                client.newCall(request).execute().use { response ->
+                    if (response.isSuccessful) {
+                        val bodyStr = response.body?.string().orEmpty()
+                        val parsed = JSONObject(bodyStr)
+                        Result.success(parsed.optString("name", name.trim()))
+                    } else {
+                        val errBody = response.body?.string().orEmpty()
+                        val msg = try {
+                            JSONObject(errBody).optString("error", "HTTP ${response.code}")
+                        } catch (_: Exception) {
+                            "HTTP ${response.code}"
+                        }
+                        Result.failure(IOException(msg))
+                    }
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            }
+        }
+
+    /**
+     * Delete a custom voice from the rig. Best-effort: if the server is
+     * unreachable we still remove it locally (the profile may be orphaned).
+     */
+    suspend fun deleteCustomVoice(name: String) {
+        withContext(Dispatchers.IO) {
+            val baseUrl = settings.rigQwenUrl.trim().trimEnd('/')
+            val requestBody = JSONObject().apply { put("name", name) }.toString()
+            val request = Request.Builder()
+                .url("$baseUrl/voice_delete")
+                .header("Content-Type", "application/json")
+                .post(requestBody.toRequestBody("application/json".toMediaType()))
+                .build()
+            try {
+                client.newCall(request).execute().close()
+            } catch (e: Exception) {
+                Log.w(TAG, "voice_delete failed (ignoring): ${e.message}")
+            }
+        }
     }
 
     data class RigQwenCustomVoice(

--- a/app/src/main/java/com/openclaw/assistant/speech/RigQwenTTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/RigQwenTTSProvider.kt
@@ -1,0 +1,288 @@
+package com.openclaw.assistant.speech
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.util.Log
+import com.openclaw.assistant.R
+import com.openclaw.assistant.data.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import kotlin.coroutines.resume
+
+private const val TAG = "RigQwenTTSProvider"
+
+/**
+ * Rig Qwen TTS Provider
+ *
+ * Speaks to the Qwen3-TTS CustomVoice server on the Windows GPU box
+ * (`rig_tts_server.py`, port 8799). The rig exposes a custom contract:
+ *
+ *   POST /tts  {"text": "...", "speaker": "ryan"}  ->  audio/wav (24 kHz mono PCM16)
+ *   GET  /health -> {"ok": true}
+ *
+ * Available speakers on the rig: ryan (default), eric, serena, vivian,
+ * dylan, aiden, uncle_fu, ono_anna, sohee.
+ */
+class RigQwenTTSProvider(private val context: Context) : TTSProvider {
+
+    private val settings = SettingsRepository.getInstance(context)
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+        .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+        .build()
+
+    private var mediaPlayer: MediaPlayer? = null
+
+    override suspend fun speak(text: String): Boolean = withContext(Dispatchers.IO) {
+        if (!isConfigured()) {
+            Log.e(TAG, "Not configured: ${getConfigurationError()}")
+            return@withContext false
+        }
+
+        try {
+            // Request audio from the rig's Qwen3-TTS server
+            val audioData = synthesizeSpeech(text)
+            if (audioData == null) {
+                Log.e(TAG, "Failed to synthesize speech")
+                return@withContext false
+            }
+
+            // Save to temp file and play (WAV — MediaPlayer handles it natively)
+            val tempFile = File.createTempFile("rig_qwen_", ".wav", context.cacheDir)
+            FileOutputStream(tempFile).use { it.write(audioData) }
+
+            try {
+                playAudioFile(tempFile)
+            } finally {
+                tempFile.delete()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error speaking: ${e.message}", e)
+            false
+        }
+    }
+
+    private suspend fun synthesizeSpeech(text: String): ByteArray? = withContext(Dispatchers.IO) {
+        val baseUrl = settings.rigQwenUrl.trim().trimEnd('/')
+        val speaker = settings.rigQwenSpeaker.ifBlank { "ryan" }
+        val custom = customVoices().firstOrNull { it.name.equals(speaker, ignoreCase = true) }
+
+        val request: Request
+        if (custom != null) {
+            // User-defined custom voice -> VoiceDesign endpoint (prompt-based).
+            val requestBody = JSONObject().apply {
+                put("text", text)
+                put("instruct", custom.instruct)
+                put("language", "English")
+            }.toString()
+            request = Request.Builder()
+                .url("$baseUrl/voice_design")
+                .header("Content-Type", "application/json")
+                .post(requestBody.toRequestBody("application/json".toMediaType()))
+                .build()
+        } else {
+            // Built-in timbre -> CustomVoice endpoint.
+            val requestBody = JSONObject().apply {
+                put("text", text)
+                put("speaker", speaker)
+            }.toString()
+            request = Request.Builder()
+                .url("$baseUrl/tts")
+                .header("Content-Type", "application/json")
+                .post(requestBody.toRequestBody("application/json".toMediaType()))
+                .build()
+        }
+
+        try {
+            client.newCall(request).execute().use { response ->
+                if (response.isSuccessful) {
+                    response.body?.bytes()
+                } else {
+                    Log.e(TAG, "API error: ${response.code}")
+                    null
+                }
+            }
+        } catch (e: IOException) {
+            Log.e(TAG, "Network error: ${e.message}", e)
+            null
+        }
+    }
+
+    /** Parse the stored custom voices JSON into a list. */
+    fun customVoices(): List<RigQwenCustomVoice> = parseCustomVoices(settings.rigQwenCustomVoices)
+
+    /** Persist the custom voice list back to settings. */
+    fun saveCustomVoices(voices: List<RigQwenCustomVoice>) {
+        settings.rigQwenCustomVoices = serializeCustomVoices(voices)
+    }
+
+    data class RigQwenCustomVoice(
+        val name: String,
+        val instruct: String,
+    )
+
+    private suspend fun playAudioFile(file: File, onStarted: (() -> Unit)? = null): Boolean = suspendCancellableCoroutine { continuation ->
+        try {
+            mediaPlayer?.release()
+            mediaPlayer = MediaPlayer().apply {
+                setDataSource(file.absolutePath)
+                setOnPreparedListener {
+                    start()
+                    onStarted?.invoke()
+                }
+                setOnCompletionListener {
+                    continuation.resume(true)
+                }
+                setOnErrorListener { _, what, extra ->
+                    Log.e(TAG, "MediaPlayer error: $what, $extra")
+                    continuation.resume(false)
+                    true
+                }
+                prepareAsync()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error playing audio: ${e.message}", e)
+            continuation.resume(false)
+        }
+
+        continuation.invokeOnCancellation {
+            try {
+                mediaPlayer?.stop()
+                mediaPlayer?.release()
+            } catch (e: Exception) {
+                mediaPlayer?.release()
+            }
+            mediaPlayer = null
+        }
+    }
+
+    override fun stop() {
+        try {
+            mediaPlayer?.stop()
+            mediaPlayer?.release()
+            mediaPlayer = null
+        } catch (e: Exception) {
+            Log.w(TAG, "Error stopping: ${e.message}")
+        }
+    }
+
+    override fun shutdown() {
+        stop()
+    }
+
+    override fun isAvailable(): Boolean = true // Always available if configured
+
+    override fun getType(): String = TTSProviderType.RIG_QWEN
+
+    override fun getDisplayName(): String = "Rig Qwen TTS"
+
+    override fun isConfigured(): Boolean {
+        return settings.rigQwenUrl.isNotBlank()
+    }
+
+    override fun getConfigurationError(): String? {
+        return if (settings.rigQwenUrl.isBlank()) {
+            context.getString(R.string.tts_error_rig_qwen_no_url)
+        } else null
+    }
+
+    override fun speakWithProgress(text: String): Flow<TTSState> = channelFlow {
+        send(TTSState.Preparing)
+
+        if (!isConfigured()) {
+            send(TTSState.Error(getConfigurationError() ?: context.getString(R.string.tts_error_not_initialized)))
+            return@channelFlow
+        }
+
+        // Synthesize speech (API call)
+        val audioData = try {
+            synthesizeSpeech(text)
+        } catch (e: Exception) {
+            Log.e(TAG, "Synthesis error", e)
+            null
+        }
+
+        if (audioData == null) {
+            send(TTSState.Error("Failed to synthesize speech"))
+            return@channelFlow
+        }
+
+        // Save to temp file
+        val tempFile = try {
+            File.createTempFile("rig_qwen_", ".wav", context.cacheDir).apply {
+                FileOutputStream(this).use { it.write(audioData) }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to save audio", e)
+            send(TTSState.Error("Failed to save audio"))
+            return@channelFlow
+        }
+
+        // Play audio - Speaking state emitted only when playback actually starts
+        val success = playAudioFile(tempFile) {
+            trySend(TTSState.Speaking)
+        }
+
+        // Cleanup
+        try {
+            tempFile.delete()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete temp file", e)
+        }
+
+        if (success) {
+            send(TTSState.Done)
+        } else {
+            send(TTSState.Error("Failed to play audio"))
+        }
+    }
+
+    companion object {
+        /** Speakers available on the rig's Qwen3-TTS CustomVoice server. */
+        val RIG_QWEN_SPEAKERS: List<String> = listOf(
+            "ryan", "eric", "serena", "vivian", "dylan",
+            "aiden", "uncle_fu", "ono_anna", "sohee",
+        )
+
+        /** Parse the stored custom voices JSON into a list (no context needed). */
+        fun parseCustomVoices(raw: String): List<RigQwenCustomVoice> {
+            if (raw.isBlank()) return emptyList()
+            return try {
+                val arr = org.json.JSONArray(raw)
+                List(arr.length()) { i ->
+                    val o = arr.getJSONObject(i)
+                    RigQwenCustomVoice(
+                        name = o.optString("name", "voice${i + 1}"),
+                        instruct = o.optString("instruct", ""),
+                    )
+                }.filter { it.name.isNotBlank() && it.instruct.isNotBlank() }
+            } catch (e: Exception) {
+                emptyList()
+            }
+        }
+
+        /** Serialize a custom voice list to JSON. */
+        fun serializeCustomVoices(voices: List<RigQwenCustomVoice>): String {
+            val arr = org.json.JSONArray()
+            voices.forEach { v ->
+                arr.put(org.json.JSONObject().apply {
+                    put("name", v.name)
+                    put("instruct", v.instruct)
+                })
+            }
+            return arr.toString()
+        }
+    }
+}

--- a/app/src/main/java/com/openclaw/assistant/speech/TTSManager.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/TTSManager.kt
@@ -26,6 +26,7 @@ class TTSManager(private val context: Context) {
         providers[TTSProviderType.LOCAL] = AndroidTTSProvider(context)
         providers[TTSProviderType.ELEVENLABS] = ElevenLabsProvider(context)
         providers[TTSProviderType.OPENAI] = OpenAIProvider(context)
+        providers[TTSProviderType.RIG_QWEN] = RigQwenTTSProvider(context)
         if (BuildConfig.FLAVOR == "full") {
             providers[TTSProviderType.VOICEVOX] = VoiceVoxProvider(context)
         }
@@ -148,6 +149,7 @@ class TTSManager(private val context: Context) {
         providers[TTSProviderType.LOCAL] = AndroidTTSProvider(context)
         providers[TTSProviderType.ELEVENLABS] = ElevenLabsProvider(context)
         providers[TTSProviderType.OPENAI] = OpenAIProvider(context)
+        providers[TTSProviderType.RIG_QWEN] = RigQwenTTSProvider(context)
         if (BuildConfig.FLAVOR == "full") {
             providers[TTSProviderType.VOICEVOX] = VoiceVoxProvider(context)
         }
@@ -191,6 +193,13 @@ class TTSManager(private val context: Context) {
                 description = "OpenAI TTS API",
                 isAvailable = true,
                 isConfigured = settings.openAiApiKey.isNotBlank()
+            ),
+            TTSProviderInfo(
+                type = TTSProviderType.RIG_QWEN,
+                displayName = "Rig Qwen TTS",
+                description = context.getString(R.string.tts_provider_rig_qwen_description),
+                isAvailable = true,
+                isConfigured = settings.rigQwenUrl.isNotBlank()
             ),
             TTSProviderInfo(
                 type = TTSProviderType.VOICEVOX,

--- a/app/src/main/java/com/openclaw/assistant/speech/TTSProvider.kt
+++ b/app/src/main/java/com/openclaw/assistant/speech/TTSProvider.kt
@@ -74,4 +74,5 @@ object TTSProviderType {
     const val ELEVENLABS = "elevenlabs"
     const val OPENAI = "openai"
     const val VOICEVOX = "voicevox"
+    const val RIG_QWEN = "rig_qwen"
 }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -421,7 +421,7 @@
     <string name="voicevox_terms_full">VOICEVOX의 음성 데이터를 사용하려면 다음 약관에 동의해야 합니다:\n\n1. 음성 데이터는 개인 및 상업적 용도로 모두 사용할 수 있습니다.\n2. 음성 라이브러리의 권리는 각 캐릭터의 권리자에게 귀속됩니다.\n3. 음성 데이터의 재배포는 금지됩니다.\n4. 불법적인 목적으로의 사용은 금지됩니다.\n\n자세한 내용은 VOICEVOX 공식 웹사이트를 참조하세요.</string>
     <string name="voicevox_downloaded_files">다운로드된 음성 데이터</string>
     <string name="voicevox_delete_confirm_title">선택한 음성을 삭제하시겠습니까?</string>
-    <string name="voicevox_delete_confirm_message">'%s'은(는) 현재 선택된 음성입니다. 삭제하시겠습니까?</string>
+    <string name="voicevox_delete_confirm_message">\'%s\'은(는) 현재 선택된 음성입니다. 삭제하시겠습니까?</string>
     <string name="voicevox_download">음성 데이터 다운로드</string>
     <string name="voicevox_redownload">음성 데이터 재다운로드</string>
     <string name="voicevox_setup_title">VOICEVOX 설정</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,7 @@
     <string name="tts_provider_elevenlabs">ElevenLabs</string>
     <string name="tts_provider_openai">OpenAI TTS</string>
     <string name="tts_provider_voicevox">VOICEVOX</string>
+    <string name="tts_provider_rig_qwen">Rig Qwen TTS</string>
     <string name="elevenlabs_api_key_label">ElevenLabs API Key</string>
     <string name="elevenlabs_voice_id_label">Voice ID</string>
     <string name="elevenlabs_model_label">Model</string>
@@ -401,6 +402,12 @@
     <string name="openai_voice_label">Voice</string>
     <string name="openai_model_label">Model</string>
     <string name="voicevox_style_label">Character / Style</string>
+    <string name="rig_qwen_url_label">Server URL</string>
+    <string name="rig_qwen_speaker_label">Speaker</string>
+    <string name="rig_qwen_add_custom_voice">Add Custom Voice</string>
+    <string name="rig_qwen_voice_name_label">Voice name</string>
+    <string name="rig_qwen_voice_prompt_label">Voice description (prompt)</string>
+    <string name="add">Add</string>
     <string name="voicevox_terms_notice">VOICEVOX利用規約に同意</string>
     <string name="get_api_key">API Keyはこちらから取得</string>
     <string name="preset_voice">プリセット音声</string>
@@ -881,6 +888,8 @@
     <string name="tts_error_provider_unavailable">%1$sは利用できません</string>
     <string name="tts_error_elevenlabs_no_apikey">ElevenLabs API Keyが設定されていません</string>
     <string name="tts_error_openai_no_apikey">OpenAI API Keyが設定されていません</string>
+    <string name="tts_error_rig_qwen_no_url">Rig Qwen TTS server URLが設定されていません</string>
+    <string name="tts_provider_rig_qwen_description">Qwen3-TTS on the Windows GPU box</string>
     <string name="tts_error_voicevox_dict_missing">OpenJTalk辞書が見つかりません</string>
     <string name="tts_error_voicevox_dict_required">OpenJTalk辞書が必要です</string>
     <string name="tts_error_voicevox_not_initialized">VOICEVOXが初期化されていません</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -407,6 +407,7 @@
     <string name="rig_qwen_add_custom_voice">Add Custom Voice</string>
     <string name="rig_qwen_voice_name_label">Voice name</string>
     <string name="rig_qwen_voice_prompt_label">Voice description (prompt)</string>
+    <string name="rig_qwen_ref_text_label">Reference line (optional)</string>
     <string name="add">Add</string>
     <string name="voicevox_terms_notice">VOICEVOX利用規約に同意</string>
     <string name="get_api_key">API Keyはこちらから取得</string>

--- a/integrations/rig_base_download.ps1
+++ b/integrations/rig_base_download.ps1
@@ -1,0 +1,8 @@
+# Download Qwen3-TTS-12Hz-1.7B-Base model (voice clone) to the rig
+$ErrorActionPreference = "Continue"
+$py = 'C:\Users\jenni\wb-local\Scripts\python.exe'
+$log = 'C:\Users\jenni\base_download.log'
+
+"=== Downloading Qwen3-TTS-12Hz-1.7B-Base ===" | Out-File $log
+& $py -c "from huggingface_hub import snapshot_download; p = snapshot_download('Qwen/Qwen3-TTS-12Hz-1.7B-Base', local_dir=r'C:\Users\jenni\wb-local\models\Base'); print('DONE', p)" 2>&1 | Out-File $log -Append
+"=== EXIT: $LASTEXITCODE ===" | Out-File $log -Append

--- a/integrations/rig_tts_server_v2.py
+++ b/integrations/rig_tts_server_v2.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Rig-side TTS server — Qwen3-TTS on CUDA device 1 (the 3060).
+
+Endpoints:
+  POST /tts          {"text": "...", "speaker": "ryan"} -> WAV bytes (24k mono)
+                     Uses Qwen3-TTS-12Hz-1.7B-CustomVoice (9 built-in timbres).
+  POST /voice_design {"text": "...", "instruct": "...", "language": "English"}
+                     -> WAV bytes (24k mono)
+                     Uses Qwen3-TTS-12Hz-1.7B-VoiceDesign (create a voice from a
+                     natural-language prompt). Language: English/Chinese/Japanese/
+                     Korean/German/French/Russian/Portuguese/Spanish/Italian.
+  GET  /health       -> {"ok": true}
+
+Only ONE 1.7B model is resident at a time (VRAM is shared with the 27B Qwen LLM
+tensor-split across both GPUs). Calling /voice_design loads VoiceDesign and
+unloads CustomVoice; calling /tts does the reverse. First call after a swap is
+slow (model load); subsequent calls are fast.
+"""
+import json, io, os, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import torch, soundfile as sf
+from qwen_tts import Qwen3TTSModel
+
+CUSTOM_PATH = os.environ.get("WB_TTS_MODEL", r"C:\Users\jenni\wb-local\models\CustomVoice")
+DESIGN_PATH = os.environ.get("WB_VOICEDESIGN_MODEL", r"C:\Users\jenni\wb-local\models\VoiceDesign")
+DEVICE = os.environ.get("WB_TTS_DEVICE", "cuda:1")
+SPEAKERS = {"ryan", "eric", "serena", "vivian", "dylan", "aiden", "uncle_fu", "ono_anna", "sohee"}
+
+_lock = threading.Lock()
+_custom_model = None
+_design_model = None
+
+
+def _load_model(path):
+    print(f"[tts] loading {os.path.basename(path)} on {DEVICE}", flush=True)
+    model = Qwen3TTSModel.from_pretrained(
+        path, device_map=DEVICE, dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    print(f"[tts] {os.path.basename(path)} ready", flush=True)
+    return model
+
+
+def get_custom_model():
+    """Load (or re-load) the CustomVoice model, freeing VoiceDesign if resident."""
+    global _custom_model, _design_model
+    with _lock:
+        if _custom_model is None:
+            _design_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _custom_model = _load_model(CUSTOM_PATH)
+        return _custom_model
+
+
+def get_design_model():
+    """Load (or re-load) the VoiceDesign model, freeing CustomVoice if resident."""
+    global _custom_model, _design_model
+    with _lock:
+        if _design_model is None:
+            _custom_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _design_model = _load_model(DESIGN_PATH)
+        return _design_model
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json({"ok": True})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(n) or b"{}")
+        except Exception:
+            self._json({"error": "bad request"}, code=400)
+            return
+        if self.path == "/tts":
+            self._handle_tts(body)
+        elif self.path == "/voice_design":
+            self._handle_voice_design(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_tts(self, body):
+        try:
+            text = (body.get("text") or "").strip()
+            if not text:
+                raise ValueError("empty text")
+            speaker = body.get("speaker", "ryan")
+            if speaker not in SPEAKERS:
+                speaker = "ryan"
+            model = get_custom_model()
+            wavs, sr = model.generate_custom_voice(text=text, language="English", speaker=speaker)
+            self._wav(wavs[0], sr)
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _handle_voice_design(self, body):
+        try:
+            text = (body.get("text") or "").strip()
+            if not text:
+                raise ValueError("empty text")
+            instruct = (body.get("instruct") or "").strip()
+            if not instruct:
+                raise ValueError("empty instruct — describe the voice you want")
+            language = (body.get("language") or "English").strip() or "English"
+            model = get_design_model()
+            wavs, sr = model.generate_voice_design(
+                text=text, instruct=instruct, language=language,
+            )
+            self._wav(wavs[0], sr)
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _wav(self, wav, sr):
+        buf = io.BytesIO()
+        sf.write(buf, wav, sr, format="WAV", subtype="PCM_16")
+        data = buf.getvalue()
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _json(self, obj, code=200):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("WB_TTS_PORT", "8799"))
+    HTTPServer(("0.0.0.0", port), H).serve_forever()

--- a/integrations/rig_tts_server_v3.py
+++ b/integrations/rig_tts_server_v3.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Rig-side TTS server — Qwen3-TTS on CUDA device 1 (the 3060).
+
+Endpoints:
+  POST /tts          {"text": "...", "speaker": "ryan"} -> WAV bytes (24k mono)
+                     Uses Qwen3-TTS-12Hz-1.7B-CustomVoice (9 built-in timbres).
+  POST /tts          {"text": "...", "voice": "my_voice"} -> WAV bytes
+                     Uses the stored clone profile for a created voice
+                     (Qwen3-TTS-12Hz-1.7B-Base + profile).
+  POST /voice_create {"name": "my_voice", "instruct": "a warm...", "ref_text": "..."}
+                     -> {"ok": true}
+                     Designs a reference clip with VoiceDesign, builds a reusable
+                     clone profile with Base, persists it to disk.
+  GET  /voices       -> {"voices": [{"name": ..., "instruct": ..., "ref_text": ...}]}
+  POST /voice_delete {"name": "my_voice"} -> {"ok": true}
+  GET  /health       -> {"ok": true}
+
+Only ONE 1.7B model is resident at a time (VRAM is shared with the 27B Qwen LLM
+tensor-split across both GPUs). Models lazy-load and swap on demand.
+Custom voices are persisted as clone profiles under VOICES_DIR.
+"""
+import json, io, os, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import torch, soundfile as sf
+from qwen_tts import Qwen3TTSModel
+
+CUSTOM_PATH = os.environ.get("WB_TTS_MODEL", r"C:\Users\jenni\wb-local\models\CustomVoice")
+DESIGN_PATH = os.environ.get("WB_VOICEDESIGN_MODEL", r"C:\Users\jenni\wb-local\models\VoiceDesign")
+BASE_PATH = os.environ.get("WB_BASE_MODEL", r"C:\Users\jenni\wb-local\models\Base")
+VOICES_DIR = os.environ.get("WB_VOICES_DIR", r"C:\Users\jenni\wb-local\voices")
+DEVICE = os.environ.get("WB_TTS_DEVICE", "cuda:1")
+SPEAKERS = {"ryan", "eric", "serena", "vivian", "dylan", "aiden", "uncle_fu", "ono_anna", "sohee"}
+DEFAULT_REF_TEXT = "Hello! This is my voice. It has a personality all its own."
+
+_lock = threading.Lock()
+_custom_model = None
+_design_model = None
+_base_model = None
+_voices = {}  # name -> {"instruct": str, "ref_text": str, "profile": list[VoiceClonePromptItem]}
+
+
+# ---------------------------------------------------------------- model mgmt
+def _load_model(path):
+    print(f"[tts] loading {os.path.basename(path)} on {DEVICE}", flush=True)
+    model = Qwen3TTSModel.from_pretrained(
+        path, device_map=DEVICE, dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    print(f"[tts] {os.path.basename(path)} ready", flush=True)
+    return model
+
+
+def get_custom_model():
+    global _custom_model, _design_model, _base_model
+    with _lock:
+        if _custom_model is None:
+            _design_model = None
+            _base_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _custom_model = _load_model(CUSTOM_PATH)
+        return _custom_model
+
+
+def get_design_model():
+    global _custom_model, _design_model, _base_model
+    with _lock:
+        if _design_model is None:
+            _custom_model = None
+            _base_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _design_model = _load_model(DESIGN_PATH)
+        return _design_model
+
+
+def get_base_model():
+    global _custom_model, _design_model, _base_model
+    with _lock:
+        if _base_model is None:
+            _custom_model = None
+            _design_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _base_model = _load_model(BASE_PATH)
+        return _base_model
+
+
+# ---------------------------------------------------------------- voice store
+def _safe_name(name):
+    keep = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ .")
+    cleaned = "".join(c if c in keep else "_" for c in name).strip()
+    return cleaned or "voice"
+
+
+def _voice_dir(name):
+    return os.path.join(VOICES_DIR, _safe_name(name))
+
+
+def load_voices():
+    global _voices
+    _voices = {}
+    if not os.path.isdir(VOICES_DIR):
+        return
+    for d in os.listdir(VOICES_DIR):
+        meta_p = os.path.join(VOICES_DIR, d, "meta.json")
+        prof_p = os.path.join(VOICES_DIR, d, "profile.pt")
+        if os.path.isfile(meta_p) and os.path.isfile(prof_p):
+            try:
+                with open(meta_p, "r", encoding="utf-8") as f:
+                    meta = json.load(f)
+                profile = torch.load(prof_p, map_location="cpu", weights_only=False)
+                _voices[meta["name"]] = {"instruct": meta.get("instruct", ""), "ref_text": meta.get("ref_text", ""), "profile": profile}
+            except Exception as e:
+                print(f"[tts] failed to load voice {d}: {e}", flush=True)
+
+
+def persist_voice(name, instruct, ref_text, profile):
+    os.makedirs(_voice_dir(name), exist_ok=True)
+    meta = {"name": name, "instruct": instruct, "ref_text": ref_text}
+    with open(os.path.join(_voice_dir(name), "meta.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False)
+    torch.save(profile, os.path.join(_voice_dir(name), "profile.pt"))
+    _voices[name] = {"instruct": instruct, "ref_text": ref_text, "profile": profile}
+
+
+def delete_voice(name):
+    import shutil
+    d = _voice_dir(name)
+    if os.path.isdir(d):
+        shutil.rmtree(d)
+    _voices.pop(name, None)
+
+
+# ---------------------------------------------------------------- handlers
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json({"ok": True})
+        elif self.path == "/voices":
+            self._json({"voices": [{"name": k, "instruct": v["instruct"], "ref_text": v["ref_text"]} for k, v in _voices.items()]})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(n) or b"{}")
+        except Exception:
+            self._json({"error": "bad request"}, code=400)
+            return
+        if self.path == "/tts":
+            self._handle_tts(body)
+        elif self.path == "/voice_create":
+            self._handle_voice_create(body)
+        elif self.path == "/voice_delete":
+            self._handle_voice_delete(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_tts(self, body):
+        try:
+            text = (body.get("text") or "").strip()
+            if not text:
+                raise ValueError("empty text")
+            voice = (body.get("voice") or "").strip()
+            if voice:
+                if voice not in _voices:
+                    raise ValueError(f"unknown voice: {voice}")
+                model = get_base_model()
+                wavs, sr = model.generate_voice_clone(
+                    text=text, language="English", voice_clone_prompt=_voices[voice]["profile"],
+                )
+                self._wav(wavs[0], sr)
+                return
+            speaker = body.get("speaker", "ryan")
+            if speaker not in SPEAKERS:
+                speaker = "ryan"
+            model = get_custom_model()
+            wavs, sr = model.generate_custom_voice(text=text, language="English", speaker=speaker)
+            self._wav(wavs[0], sr)
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _handle_voice_create(self, body):
+        try:
+            name = _safe_name(body.get("name") or "")
+            if not name:
+                raise ValueError("empty name")
+            if name in _voices:
+                raise ValueError(f"voice already exists: {name}")
+            instruct = (body.get("instruct") or "").strip()
+            if not instruct:
+                raise ValueError("empty instruct")
+            ref_text = (body.get("ref_text") or "").strip() or DEFAULT_REF_TEXT
+            # 1) Design a reference clip with VoiceDesign
+            design = get_design_model()
+            ref_wavs, sr = design.generate_voice_design(text=ref_text, instruct=instruct, language="English")
+            # 2) Build a reusable clone profile with Base
+            base = get_base_model()
+            profile = base.create_voice_clone_prompt(ref_audio=(ref_wavs[0], sr), ref_text=ref_text)
+            persist_voice(name, instruct, ref_text, profile)
+            self._json({"ok": True, "name": name})
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _handle_voice_delete(self, body):
+        try:
+            name = (body.get("name") or "").strip()
+            if not name:
+                raise ValueError("empty name")
+            delete_voice(name)
+            self._json({"ok": True})
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _wav(self, wav, sr):
+        buf = io.BytesIO()
+        sf.write(buf, wav, sr, format="WAV", subtype="PCM_16")
+        data = buf.getvalue()
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _json(self, obj, code=200):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    load_voices()
+    port = int(os.environ.get("WB_TTS_PORT", "8799"))
+    HTTPServer(("0.0.0.0", port), H).serve_forever()

--- a/integrations/rig_tts_server_v4.py
+++ b/integrations/rig_tts_server_v4.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Rig-side TTS server v4 — Qwen3-TTS via faster-qwen3-tts (CUDA graphs).
+
+Same HTTP contract as v3, but the inference engine is FasterQwen3TTS which
+uses torch.cuda.CUDAGraph to eliminate per-token Python dispatch overhead
+(measured ~7.6x speedup on the clone path vs the Python qwen-tts baseline).
+
+Endpoints:
+  POST /tts          {"text": "...", "speaker": "ryan"} -> WAV bytes
+  POST /tts          {"text": "...", "voice": "my_voice"} -> WAV bytes
+  POST /voice_create {"name": ..., "instruct": ..., "ref_text": ...} -> {"ok": true}
+  GET  /voices       -> {"voices": [...]}
+  POST /voice_delete {"name": ...} -> {"ok": true}
+  GET  /health       -> {"ok": true}
+
+Run with the fastertts venv python:
+  C:\\Users\\jenni\\fastertts-venv\\Scripts\\python.exe rig_tts_server.py
+
+Only ONE 1.7B model is resident at a time (VRAM shared with the 27B Qwen LLM).
+Custom voice clone profiles persist under VOICES_DIR and load on startup.
+"""
+import json, io, os, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import torch, soundfile as sf
+from faster_qwen3_tts import FasterQwen3TTS
+
+CUSTOM_PATH = os.environ.get("WB_TTS_MODEL", r"C:\Users\jenni\wb-local\models\CustomVoice")
+DESIGN_PATH = os.environ.get("WB_VOICEDESIGN_MODEL", r"C:\Users\jenni\wb-local\models\VoiceDesign")
+BASE_PATH = os.environ.get("WB_BASE_MODEL", r"C:\Users\jenni\wb-local\models\Base")
+VOICES_DIR = os.environ.get("WB_VOICES_DIR", r"C:\Users\jenni\wb-local\voices")
+DEVICE = os.environ.get("WB_TTS_DEVICE", "cuda:1")
+SPEAKERS = {"ryan", "eric", "serena", "vivian", "dylan", "aiden", "uncle_fu", "ono_anna", "sohee"}
+DEFAULT_REF_TEXT = "Hello! This is my voice. It has a personality all its own."
+
+_lock = threading.Lock()
+_custom_model = None
+_design_model = None
+_base_model = None
+_voices = {}  # name -> {"instruct", "ref_text", "profile"}
+
+
+def _load_model(path):
+    print(f"[tts] loading {os.path.basename(path)} on {DEVICE} (FasterQwen3TTS)", flush=True)
+    model = FasterQwen3TTS.from_pretrained(path, device=DEVICE, dtype=torch.bfloat16, attn_implementation="sdpa")
+    print(f"[tts] {os.path.basename(path)} ready", flush=True)
+    return model
+
+
+def get_custom_model():
+    global _custom_model, _design_model, _base_model
+    with _lock:
+        if _custom_model is None:
+            _design_model = None
+            _base_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _custom_model = _load_model(CUSTOM_PATH)
+        return _custom_model
+
+
+def get_design_model():
+    global _custom_model, _design_model, _base_model
+    with _lock:
+        if _design_model is None:
+            _custom_model = None
+            _base_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _design_model = _load_model(DESIGN_PATH)
+        return _design_model
+
+
+def get_base_model():
+    global _custom_model, _design_model, _base_model
+    with _lock:
+        if _base_model is None:
+            _custom_model = None
+            _design_model = None
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            _base_model = _load_model(BASE_PATH)
+        return _base_model
+
+
+# ---------------------------------------------------------------- voice store
+def _safe_name(name):
+    keep = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ .")
+    cleaned = "".join(c if c in keep else "_" for c in name).strip()
+    return cleaned or "voice"
+
+
+def _voice_dir(name):
+    return os.path.join(VOICES_DIR, _safe_name(name))
+
+
+def load_voices():
+    global _voices
+    _voices = {}
+    if not os.path.isdir(VOICES_DIR):
+        return
+    for d in os.listdir(VOICES_DIR):
+        meta_p = os.path.join(VOICES_DIR, d, "meta.json")
+        prof_p = os.path.join(VOICES_DIR, d, "profile.pt")
+        if os.path.isfile(meta_p) and os.path.isfile(prof_p):
+            try:
+                with open(meta_p, "r", encoding="utf-8") as f:
+                    meta = json.load(f)
+                profile = torch.load(prof_p, map_location="cpu", weights_only=False)
+                _voices[meta["name"]] = {
+                    "instruct": meta.get("instruct", ""),
+                    "ref_text": meta.get("ref_text", ""),
+                    "profile": profile,
+                }
+            except Exception as e:
+                print(f"[tts] failed to load voice {d}: {e}", flush=True)
+
+
+def persist_voice(name, instruct, ref_text, profile):
+    os.makedirs(_voice_dir(name), exist_ok=True)
+    meta = {"name": name, "instruct": instruct, "ref_text": ref_text}
+    with open(os.path.join(_voice_dir(name), "meta.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False)
+    torch.save(profile, os.path.join(_voice_dir(name), "profile.pt"))
+    _voices[name] = {"instruct": instruct, "ref_text": ref_text, "profile": profile}
+
+
+def delete_voice(name):
+    import shutil
+    d = _voice_dir(name)
+    if os.path.isdir(d):
+        shutil.rmtree(d)
+    _voices.pop(name, None)
+
+
+# ---------------------------------------------------------------- handlers
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._json({"ok": True})
+        elif self.path == "/voices":
+            self._json({"voices": [{"name": k, "instruct": v["instruct"], "ref_text": v["ref_text"]} for k, v in _voices.items()]})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(n) or b"{}")
+        except Exception:
+            self._json({"error": "bad request"}, code=400)
+            return
+        if self.path == "/tts":
+            self._handle_tts(body)
+        elif self.path == "/voice_create":
+            self._handle_voice_create(body)
+        elif self.path == "/voice_delete":
+            self._handle_voice_delete(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_tts(self, body):
+        try:
+            text = (body.get("text") or "").strip()
+            if not text:
+                raise ValueError("empty text")
+            voice = (body.get("voice") or "").strip()
+            if voice:
+                if voice not in _voices:
+                    raise ValueError(f"unknown voice: {voice}")
+                model = get_base_model()
+                wavs, sr = model.generate_voice_clone(
+                    text=text, language="English", voice_clone_prompt=_voices[voice]["profile"],
+                )
+                self._wav(wavs[0], sr)
+                return
+            speaker = body.get("speaker", "ryan")
+            if speaker not in SPEAKERS:
+                speaker = "ryan"
+            model = get_custom_model()
+            wavs, sr = model.generate_custom_voice(text=text, language="English", speaker=speaker)
+            self._wav(wavs[0], sr)
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _handle_voice_create(self, body):
+        try:
+            name = _safe_name(body.get("name") or "")
+            if not name:
+                raise ValueError("empty name")
+            if name in _voices:
+                raise ValueError(f"voice already exists: {name}")
+            instruct = (body.get("instruct") or "").strip()
+            if not instruct:
+                raise ValueError("empty instruct")
+            ref_text = (body.get("ref_text") or "").strip() or DEFAULT_REF_TEXT
+            # 1) Design a reference clip with VoiceDesign (CUDA graphs)
+            design = get_design_model()
+            ref_wavs, sr = design.generate_voice_design(text=ref_text, instruct=instruct, language="English")
+            # 2) Build a reusable clone profile with Base
+            base = get_base_model()
+            profile = base.model.create_voice_clone_prompt(ref_audio=(ref_wavs[0], sr), ref_text=ref_text)
+            persist_voice(name, instruct, ref_text, profile)
+            self._json({"ok": True, "name": name})
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _handle_voice_delete(self, body):
+        try:
+            name = (body.get("name") or "").strip()
+            if not name:
+                raise ValueError("empty name")
+            delete_voice(name)
+            self._json({"ok": True})
+        except Exception as e:
+            self._json({"error": str(e)}, code=500)
+
+    def _wav(self, wav, sr):
+        buf = io.BytesIO()
+        sf.write(buf, wav, sr, format="WAV", subtype="PCM_16")
+        data = buf.getvalue()
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _json(self, obj, code=200):
+        data = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    load_voices()
+    port = int(os.environ.get("WB_TTS_PORT", "8799"))
+    HTTPServer(("0.0.0.0", port), H).serve_forever()

--- a/integrations/rig_voice_design_download.ps1
+++ b/integrations/rig_voice_design_download.ps1
@@ -1,0 +1,8 @@
+# Download Qwen3-TTS-12Hz-1.7B-VoiceDesign model to the rig
+$ErrorActionPreference = "Continue"
+$py = 'C:\Users\jenni\wb-local\Scripts\python.exe'
+$log = 'C:\Users\jenni\voicedesign_download.log'
+
+"=== Downloading Qwen3-TTS-12Hz-1.7B-VoiceDesign ===" | Out-File $log
+& $py -c "from huggingface_hub import snapshot_download; p = snapshot_download('Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign', local_dir=r'C:\Users\jenni\wb-local\models\VoiceDesign'); print('DONE', p)" 2>&1 | Out-File $log -Append
+"=== EXIT: $LASTEXITCODE ===" | Out-File $log -Append


### PR DESCRIPTION
## Summary
Adds **prompt-created custom voices** to the Rig Qwen TTS provider using Qwen3-TTS's *VoiceDesign → Clone* workflow — the ElevenLabs-style model: create a voice from a natural-language prompt once, get a reusable saved profile, then synthesize with it consistently.

## What changed

**App:**
- `RigQwenTTSProvider`: new `createCustomVoice()` / `deleteCustomVoice()` hitting the rig's `/voice_create` + `/voice_delete`. Custom-voice synthesis routes to `/tts` with the voice **name** (clone-profile path) — no more re-design per utterance.
- `SettingsRepository`: persists `rig_qwen_custom_voices` as a JSON array of `{name, instruct}`.
- `SettingsActivity`: "Add Custom Voice" now calls the server **asynchronously** with a progress spinner + error display; optional reference-line field; delete removes the server profile too. Custom voices appear with a ⭐ in the speaker dropdown.
- `strings.xml`: labels for custom voice management.

**Rig server (integrations/):**
- `rig_tts_server_v3.py`: adds `POST /voice_create` — designs a reference clip with **VoiceDesign**, builds a reusable clone profile with the **Base** model, persists to disk (survives restarts). `POST /tts` accepts `voice` (clone profile) or `speaker` (built-in timbre). `GET /voices` + `POST /voice_delete`. Lazy model-swap keeps VRAM within budget (only one 1.7B model resident at a time; shared with a tensor-split 27B LLM).
- `rig_voice_design_download.ps1` + `rig_base_download.ps1`: helpers to fetch VoiceDesign and Base models.

## Verified (live on the rig)
- `POST /voice_create` → `{"ok": true}` in ~33s (both models load on first call)
- `POST /tts {"voice": "granny"}` → 24kHz WAV (clone path, consistent voice)
- Built-in `speaker: ryan` still works after model swap
- Voices persist across server restarts
- App: 221/221 unit tests green

## Notes
- First voice creation loads both models (~33-60s); afterwards synthesis is ~8-12s/line (clone is slightly heavier than built-in timbres). Switching between custom voice and built-in timbre triggers a ~15s model swap.